### PR TITLE
Fix covariance of zero-observation arrays and corresponding test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ ndarray-rand = "0.8"
 [patch.crates-io]
 ndarray = { git = "https://github.com/jturner314/ndarray.git", branch = "master" }
 noisy_float = { git = "https://github.com/SergiusIW/noisy_float-rs.git", rev = "c33a94803987475bbd205c9ff5a697af533f9a17" }
+matrixmultiply = { git = "https://github.com/jturner314/matrixmultiply.git", rev = "344f4b43c55fcf7b20be20baff38406ebe9afbfb" }

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -146,7 +146,7 @@ mod tests {
         // Negative ddof (-1 < 0) to avoid invalid-ddof panic
         let cov = a.cov(-1.);
         assert_eq!(cov.shape(), &[2, 2]);
-        cov.mapv(|x| x.is_nan());
+        cov.mapv(|x| assert_eq!(x, 0.));
     }
 
     #[test]


### PR DESCRIPTION
`matrixmultiply` (used by `ndarray` for matrix multiplication) has a bug that results in uninitialized memory being returned if the matrices being multiplied have shapes `m × 0` and `0 × n`. This PR adds a patch to fix this (bluss/matrixmultiply#21). It also fixes `test_covariance_zero_observations` to test that all elements are zero.