### PR TITLE
Replace min/max, make quantile_mut return None for empty arrays, and fix docs

### DIFF
--- a/src/histogram/strategies.rs
+++ b/src/histogram/strategies.rs
@@ -181,7 +181,7 @@ impl<T> BinsBuildingStrategy for Sqrt<T>
 {
     type Elem = T;
 
-    /// **Panics** if the array is constant or if `a.len()==0` and division by 0 panics for `T`.
+    /// **Panics** if the array is constant or if `a.len()==0`.
     fn from_array<S>(a: &ArrayBase<S, Ix1>) -> Self
     where
         S: Data<Elem=Self::Elem>
@@ -220,7 +220,7 @@ impl<T> BinsBuildingStrategy for Rice<T>
 {
     type Elem = T;
 
-    /// **Panics** if the array is constant or if `a.len()==0` and division by 0 panics for `T`.
+    /// **Panics** if the array is constant or if `a.len()==0`.
     fn from_array<S>(a: &ArrayBase<S, Ix1>) -> Self
     where
         S: Data<Elem=Self::Elem>
@@ -259,7 +259,7 @@ impl<T> BinsBuildingStrategy for Sturges<T>
 {
     type Elem = T;
 
-    /// **Panics** if the array is constant or if `a.len()==0` and division by 0 panics for `T`.
+    /// **Panics** if the array is constant or if `a.len()==0`.
     fn from_array<S>(a: &ArrayBase<S, Ix1>) -> Self
     where
         S: Data<Elem=Self::Elem>
@@ -298,7 +298,7 @@ impl<T> BinsBuildingStrategy for FreedmanDiaconis<T>
 {
     type Elem = T;
 
-    /// **Panics** if `IQR==0` or if `a.len()==0` and division by 0 panics for `T`.
+    /// **Panics** if `IQR==0` or if `a.len()==0`.
     fn from_array<S>(a: &ArrayBase<S, Ix1>) -> Self
     where
         S: Data<Elem=Self::Elem>
@@ -349,8 +349,7 @@ impl<T> BinsBuildingStrategy for Auto<T>
 {
     type Elem = T;
 
-    /// **Panics** if `IQR==0`, the array is constant or if
-    /// `a.len()==0` and division by 0 panics for `T`.
+    /// **Panics** if `IQR==0`, the array is constant, or `a.len()==0`.
     fn from_array<S>(a: &ArrayBase<S, Ix1>) -> Self
     where
         S: Data<Elem=Self::Elem>
@@ -403,7 +402,7 @@ impl<T> Auto<T>
 ///
 /// `bin_width = (max - min)/n`
 ///
-/// **Panics** if division by 0 panics for `T`.
+/// **Panics** if `n_bins == 0` and division by 0 panics for `T`.
 fn compute_bin_width<T>(min: T, max: T, n_bins: usize) -> T
 where
     T: Ord + Clone + FromPrimitive + NumOps + Zero,

--- a/src/histogram/strategies.rs
+++ b/src/histogram/strategies.rs
@@ -188,8 +188,8 @@ impl<T> BinsBuildingStrategy for Sqrt<T>
     {
         let n_elems = a.len();
         let n_bins = (n_elems as f64).sqrt().round() as usize;
-        let min = a.min().clone();
-        let max = a.max().clone();
+        let min = a.min().unwrap().clone();
+        let max = a.max().unwrap().clone();
         let bin_width = compute_bin_width(min.clone(), max.clone(), n_bins);
         let builder = EquiSpaced::new(bin_width, min, max);
         Self { builder }
@@ -227,8 +227,8 @@ impl<T> BinsBuildingStrategy for Rice<T>
     {
         let n_elems = a.len();
         let n_bins = (2. * (n_elems as f64).powf(1./3.)).round() as usize;
-        let min = a.min().clone();
-        let max = a.max().clone();
+        let min = a.min().unwrap().clone();
+        let max = a.max().unwrap().clone();
         let bin_width = compute_bin_width(min.clone(), max.clone(), n_bins);
         let builder = EquiSpaced::new(bin_width, min, max);
         Self { builder }
@@ -266,8 +266,8 @@ impl<T> BinsBuildingStrategy for Sturges<T>
     {
         let n_elems = a.len();
         let n_bins = (n_elems as f64).log2().round() as usize + 1;
-        let min = a.min().clone();
-        let max = a.max().clone();
+        let min = a.min().unwrap().clone();
+        let max = a.max().unwrap().clone();
         let bin_width = compute_bin_width(min.clone(), max.clone(), n_bins);
         let builder = EquiSpaced::new(bin_width, min, max);
         Self { builder }
@@ -311,8 +311,8 @@ impl<T> BinsBuildingStrategy for FreedmanDiaconis<T>
         let iqr = third_quartile - first_quartile;
 
         let bin_width = FreedmanDiaconis::compute_bin_width(n_points, iqr);
-        let min = a_copy.min().clone();
-        let max = a_copy.max().clone();
+        let min = a_copy.min().unwrap().clone();
+        let max = a_copy.max().unwrap().clone();
         let builder = EquiSpaced::new(bin_width, min, max);
         Self { builder }
     }

--- a/src/histogram/strategies.rs
+++ b/src/histogram/strategies.rs
@@ -306,8 +306,8 @@ impl<T> BinsBuildingStrategy for FreedmanDiaconis<T>
         let n_points = a.len();
 
         let mut a_copy = a.to_owned();
-        let first_quartile = a_copy.quantile_mut::<Nearest>(0.25);
-        let third_quartile = a_copy.quantile_mut::<Nearest>(0.75);
+        let first_quartile = a_copy.quantile_mut::<Nearest>(0.25).unwrap();
+        let third_quartile = a_copy.quantile_mut::<Nearest>(0.75).unwrap();
         let iqr = third_quartile - first_quartile;
 
         let bin_width = FreedmanDiaconis::compute_bin_width(n_points, iqr);

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -177,19 +177,12 @@ where
 {
     /// Finds the elementwise minimum of the array.
     ///
-    /// **Panics** if the array is empty.
-    fn min(&self) -> &A
-    where
-        A: Ord;
-
-    /// Finds the elementwise minimum of the array.
-    ///
     /// Returns `None` if any of the pairwise orderings tested by the function
     /// are undefined. (For example, this occurs if there are any
     /// floating-point NaN values in the array.)
     ///
     /// Additionally, returns `None` if the array is empty.
-    fn min_partialord(&self) -> Option<&A>
+    fn min(&self) -> Option<&A>
     where
         A: PartialOrd;
 
@@ -205,19 +198,12 @@ where
 
     /// Finds the elementwise maximum of the array.
     ///
-    /// **Panics** if the array is empty.
-    fn max(&self) -> &A
-    where
-        A: Ord;
-
-    /// Finds the elementwise maximum of the array.
-    ///
     /// Returns `None` if any of the pairwise orderings tested by the function
     /// are undefined. (For example, this occurs if there are any
     /// floating-point NaN values in the array.)
     ///
     /// Additionally, returns `None` if the array is empty.
-    fn max_partialord(&self) -> Option<&A>
+    fn max(&self) -> Option<&A>
     where
         A: PartialOrd;
 
@@ -285,22 +271,11 @@ where
     S: Data<Elem = A>,
     D: Dimension,
 {
-    fn min(&self) -> &A
-    where
-        A: Ord,
-    {
-        let first = self
-            .iter()
-            .next()
-            .expect("Attempted to find min of empty array.");
-        self.fold(first, |acc, elem| if elem < acc { elem } else { acc })
-    }
-
-    fn min_partialord(&self) -> Option<&A>
+    fn min(&self) -> Option<&A>
     where
         A: PartialOrd,
     {
-        let first = self.iter().next()?;
+        let first = self.first()?;
         self.fold(Some(first), |acc, elem| match elem.partial_cmp(acc?)? {
             cmp::Ordering::Less => Some(elem),
             _ => acc,
@@ -312,7 +287,7 @@ where
         A: MaybeNan,
         A::NotNan: Ord,
     {
-        let first = self.iter().next().and_then(|v| v.try_as_not_nan());
+        let first = self.first().and_then(|v| v.try_as_not_nan());
         A::from_not_nan_ref_opt(self.fold_skipnan(first, |acc, elem| {
             Some(match acc {
                 Some(acc) => acc.min(elem),
@@ -321,22 +296,11 @@ where
         }))
     }
 
-    fn max(&self) -> &A
-    where
-        A: Ord,
-    {
-        let first = self
-            .iter()
-            .next()
-            .expect("Attempted to find max of empty array.");
-        self.fold(first, |acc, elem| if elem > acc { elem } else { acc })
-    }
-
-    fn max_partialord(&self) -> Option<&A>
+    fn max(&self) -> Option<&A>
     where
         A: PartialOrd,
     {
-        let first = self.iter().next()?;
+        let first = self.first()?;
         self.fold(Some(first), |acc, elem| match elem.partial_cmp(acc?)? {
             cmp::Ordering::Greater => Some(elem),
             _ => acc,
@@ -348,7 +312,7 @@ where
         A: MaybeNan,
         A::NotNan: Ord,
     {
-        let first = self.iter().next().and_then(|v| v.try_as_not_nan());
+        let first = self.first().and_then(|v| v.try_as_not_nan());
         A::from_not_nan_ref_opt(self.fold_skipnan(first, |acc, elem| {
             Some(match acc {
                 Some(acc) => acc.max(elem),

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -245,8 +245,8 @@ where
     /// - worst case: O(`m`^2);
     /// where `m` is the number of elements in the array.
     ///
-    /// **Panics** if `axis` is out of bounds or if `q` is not between
-    /// `0.` and `1.` (inclusive).
+    /// **Panics** if `axis` is out of bounds, if the axis has length 0, or if
+    /// `q` is not between `0.` and `1.` (inclusive).
     fn quantile_axis_mut<I>(&mut self, axis: Axis, q: f64) -> Array<A, D::Smaller>
     where
         D: RemoveAxis,

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -406,8 +406,10 @@ pub trait QuantileExt1d<A, S>
     /// - worst case: O(`m`^2);
     /// where `m` is the number of elements in the array.
     ///
+    /// Returns `None` if the array is empty.
+    ///
     /// **Panics** if `q` is not between `0.` and `1.` (inclusive).
-    fn quantile_mut<I>(&mut self, q: f64) -> A
+    fn quantile_mut<I>(&mut self, q: f64) -> Option<A>
     where
         A: Ord + Clone,
         S: DataMut,
@@ -418,13 +420,17 @@ impl<A, S> QuantileExt1d<A, S> for ArrayBase<S, Ix1>
     where
         S: Data<Elem = A>,
 {
-    fn quantile_mut<I>(&mut self, q: f64) -> A
+    fn quantile_mut<I>(&mut self, q: f64) -> Option<A>
     where
         A: Ord + Clone,
         S: DataMut,
         I: Interpolate<A>,
     {
-        self.quantile_axis_mut::<I>(Axis(0), q).into_scalar()
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.quantile_axis_mut::<I>(Axis(0), q).into_scalar())
+        }
     }
 }
 

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -70,6 +70,20 @@ fn test_quantile_axis_mut_with_odd_axis_length() {
 }
 
 #[test]
+#[should_panic]
+fn test_quantile_axis_mut_with_zero_axis_length() {
+    let mut a = Array2::<i32>::zeros((5, 0));
+    a.quantile_axis_mut::<Lower>(Axis(1), 0.5);
+}
+
+#[test]
+fn test_quantile_axis_mut_with_empty_array() {
+    let mut a = Array2::<i32>::zeros((5, 0));
+    let p = a.quantile_axis_mut::<Lower>(Axis(0), 0.5);
+    assert_eq!(p.shape(), &[0]);
+}
+
+#[test]
 fn test_quantile_axis_mut_with_even_axis_length() {
     let mut b = arr2(&[[1, 3, 2, 10], [2, 4, 3, 11], [3, 5, 6, 12], [4, 6, 7, 13]]);
     let q = b.quantile_axis_mut::<Lower>(Axis(0), 0.5);

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -11,16 +11,13 @@ use ndarray_stats::{
 #[test]
 fn test_min() {
     let a = array![[1, 5, 3], [2, 0, 6]];
-    assert_eq!(a.min(), &0);
-}
+    assert_eq!(a.min(), Some(&0));
 
-#[test]
-fn test_min_partialord() {
     let a = array![[1., 5., 3.], [2., 0., 6.]];
-    assert_eq!(a.min_partialord(), Some(&0.));
+    assert_eq!(a.min(), Some(&0.));
 
     let a = array![[1., 5., 3.], [2., ::std::f64::NAN, 6.]];
-    assert_eq!(a.min_partialord(), None);
+    assert_eq!(a.min(), None);
 }
 
 #[test]
@@ -41,16 +38,13 @@ fn test_min_skipnan_all_nan() {
 #[test]
 fn test_max() {
     let a = array![[1, 5, 7], [2, 0, 6]];
-    assert_eq!(a.max(), &7);
-}
+    assert_eq!(a.max(), Some(&7));
 
-#[test]
-fn test_max_partialord() {
     let a = array![[1., 5., 7.], [2., 0., 6.]];
-    assert_eq!(a.max_partialord(), Some(&7.));
+    assert_eq!(a.max(), Some(&7.));
 
     let a = array![[1., 5., 7.], [2., ::std::f64::NAN, 6.]];
-    assert_eq!(a.max_partialord(), None);
+    assert_eq!(a.max(), None);
 }
 
 #[test]


### PR DESCRIPTION
This PR does a few things:

* Replace the old `min`/`max` methods with the old `min_partialord`/`max_partialord`. (Rename `min_partialord`/`max_partialord` to `min`/`max`.) See [this comment](https://github.com/rust-ndarray/ndarray/issues/512#issuecomment-433239806) for more explanation. The primary issue with the old `min`/`max` methods is that they panicked on empty arrays.
* Make `quantile_mut` return `None` for empty arrays. It's easy to forget about the possibility of empty arrays, so it's important to remind the user of the possibility and force them to handle it. See [this comment](https://github.com/rust-ndarray/ndarray/issues/512#issuecomment-433239806) for more justification.
* Fix the conditions for panicking in the docs of histogram strategies and `quantile_mut`.

Edit: I'm uncomfortable with the histogram strategies panicking in so many cases, but we can fix that in a later version.