### PR TITLE
Update subview calls to use index_axis

### DIFF
--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -66,7 +66,7 @@ fn test_max_skipnan_all_nan() {
 fn test_quantile_axis_mut_with_odd_axis_length() {
     let mut a = arr2(&[[1, 3, 2, 10], [2, 4, 3, 11], [3, 5, 6, 12]]);
     let p = a.quantile_axis_mut::<Lower>(Axis(0), 0.5);
-    assert!(p == a.subview(Axis(0), 1));
+    assert!(p == a.index_axis(Axis(0), 1));
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn test_quantile_axis_mut_with_empty_array() {
 fn test_quantile_axis_mut_with_even_axis_length() {
     let mut b = arr2(&[[1, 3, 2, 10], [2, 4, 3, 11], [3, 5, 6, 12], [4, 6, 7, 13]]);
     let q = b.quantile_axis_mut::<Lower>(Axis(0), 0.5);
-    assert!(q == b.subview(Axis(0), 1));
+    assert!(q == b.index_axis(Axis(0), 1));
 }
 
 #[test]


### PR DESCRIPTION
The `.subview()` method is deprecated in the latest `ndarray`.