### PR TITLE
Fix coverage testing in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,16 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+before_cache: |
+  if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
+    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
+  fi
 script:
 - cargo clean
 - cargo build
 - cargo test
 after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+  if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
     cargo tarpaulin --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi


### PR DESCRIPTION
According to the tarpaulin readme, tarpaulin now requires nightly and cargo is the recommended install method.