### PR TITLE
Fix overflow for Midpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,7 @@
 //! - [`partitioning`];
 //! - [`correlation analysis`] (covariance, pearson correlation);
 //! - [`histogram computation`].
-//
-//! !
+//!
 //! Please feel free to contribute new functionality! A roadmap can be found [`here`].
 //!
 //! Our work is inspired by other existing statistical packages such as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
 //! - [`partitioning`];
 //! - [`correlation analysis`] (covariance, pearson correlation);
 //! - [`histogram computation`].
-//!
+//
+//! !
 //! Please feel free to contribute new functionality! A roadmap can be found [`here`].
 //!
 //! Our work is inspired by other existing statistical packages such as

--- a/src/maybe_nan/impl_not_none.rs
+++ b/src/maybe_nan/impl_not_none.rs
@@ -2,7 +2,7 @@ use super::NotNone;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::cmp;
 use std::fmt;
-use std::ops::{Add, Deref, DerefMut, Div, Mul, Sub};
+use std::ops::{Add, Deref, DerefMut, Div, Mul, Sub, Rem};
 
 impl<T> Deref for NotNone<T> {
     type Target = T;
@@ -93,6 +93,14 @@ impl<T: Div> Div for NotNone<T> {
     #[inline]
     fn div(self, rhs: Self) -> Self::Output {
         self.map(|v| v.div(rhs.unwrap()))
+    }
+}
+
+impl<T: Rem> Rem for NotNone<T> {
+    type Output = NotNone<T::Output>;
+    #[inline]
+    fn rem(self, rhs: Self) -> Self::Output {
+        self.map(|v| v.rem(rhs.unwrap()))
     }
 }
 

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -8,7 +8,7 @@ use {MaybeNan, MaybeNanExt, Sort1dExt};
 pub mod interpolate {
     use ndarray::azip;
     use ndarray::prelude::*;
-    use num_traits::{FromPrimitive, ToPrimitive};
+    use num_traits::{FromPrimitive, ToPrimitive, NumOps};
     use std::ops::{Add, Div, Sub};
 
     /// Used to provide an interpolation strategy to [`quantile_axis_mut`].
@@ -116,7 +116,7 @@ pub mod interpolate {
 
     impl<T> Interpolate<T> for Midpoint
     where
-        T: Add<T, Output = T> + Sub<T, Output=T> + Div<T, Output = T> + Clone + FromPrimitive,
+        T: NumOps + Clone + FromPrimitive,
     {
         fn needs_lower(_q: f64, _len: usize) -> bool {
             true
@@ -147,7 +147,7 @@ pub mod interpolate {
 
     impl<T> Interpolate<T> for Linear
     where
-        T: Add<T, Output = T> + Clone + FromPrimitive + ToPrimitive,
+        T: NumOps + Clone + FromPrimitive + ToPrimitive,
     {
         fn needs_lower(_q: f64, _len: usize) -> bool {
             true

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -9,7 +9,6 @@ pub mod interpolate {
     use ndarray::azip;
     use ndarray::prelude::*;
     use num_traits::{FromPrimitive, ToPrimitive, NumOps};
-    use std::ops::{Add, Div, Sub};
 
     /// Used to provide an interpolation strategy to [`quantile_axis_mut`].
     ///

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -6,6 +6,7 @@ use ndarray::prelude::*;
 use ndarray_stats::{
     interpolate::{Higher, Linear, Lower, Midpoint, Nearest},
     QuantileExt,
+    Quantile1dExt,
 };
 
 #[test]
@@ -147,4 +148,14 @@ fn test_quantile_axis_skipnan_mut_linear_opt_i32() {
     assert_eq!(q.shape(), &[2]);
     assert_eq!(q[0], Some(3));
     assert!(q[1].is_none());
+}
+
+#[test]
+fn test_midpoint_overflow() {
+    // Regression test
+    // This triggered an overflow panic with a naive Midpoint implementation: (a+b)/2
+    let mut a: Array1<u8> = array![129, 130, 130, 131];
+    let median = a.quantile_mut::<Midpoint>(0.5).unwrap();
+    let expected_median = 130;
+    assert_eq!(median, expected_median);
 }


### PR DESCRIPTION
This provides a fix for #27, I have also included a test to reproduce the issue so that we can be aware of regressions.
Unfortunately, it's a breaking change PR because I have had to add `Sub` to the trait bound. Should we just use `NumOps` for all `Interpolate` implementations @jturner314?