### PR TITLE
Clarify which (arg)min/max index/value is returned

### DIFF
--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -182,13 +182,17 @@ where
     S: Data<Elem = A>,
     D: Dimension,
 {
-    /// Finds the first index of the minimum value of the array.
+    /// Finds the index of the minimum value of the array.
     ///
     /// Returns `None` if any of the pairwise orderings tested by the function
     /// are undefined. (For example, this occurs if there are any
     /// floating-point NaN values in the array.)
     ///
     /// Returns `None` if the array is empty.
+    ///
+    /// Even if there are multiple (equal) elements that are minima, only one
+    /// index is returned. (Which one is returned is unspecified and may depend
+    /// on the memory layout of the array.)
     ///
     /// # Example
     ///
@@ -214,11 +218,19 @@ where
     /// floating-point NaN values in the array.)
     ///
     /// Additionally, returns `None` if the array is empty.
+    ///
+    /// Even if there are multiple (equal) elements that are minima, only one
+    /// is returned. (Which one is returned is unspecified and may depend on
+    /// the memory layout of the array.)
     fn min(&self) -> Option<&A>
     where
         A: PartialOrd;
 
     /// Finds the elementwise minimum of the array, skipping NaN values.
+    ///
+    /// Even if there are multiple (equal) elements that are minima, only one
+    /// is returned. (Which one is returned is unspecified and may depend on
+    /// the memory layout of the array.)
     ///
     /// **Warning** This method will return a NaN value if none of the values
     /// in the array are non-NaN values. Note that the NaN value might not be
@@ -228,13 +240,17 @@ where
         A: MaybeNan,
         A::NotNan: Ord;
 
-    /// Finds the first index of the maximum value of the array.
+    /// Finds the index of the maximum value of the array.
     ///
     /// Returns `None` if any of the pairwise orderings tested by the function
     /// are undefined. (For example, this occurs if there are any
     /// floating-point NaN values in the array.)
     ///
     /// Returns `None` if the array is empty.
+    ///
+    /// Even if there are multiple (equal) elements that are maxima, only one
+    /// index is returned. (Which one is returned is unspecified and may depend
+    /// on the memory layout of the array.)
     ///
     /// # Example
     ///
@@ -260,11 +276,19 @@ where
     /// floating-point NaN values in the array.)
     ///
     /// Additionally, returns `None` if the array is empty.
+    ///
+    /// Even if there are multiple (equal) elements that are maxima, only one
+    /// is returned. (Which one is returned is unspecified and may depend on
+    /// the memory layout of the array.)
     fn max(&self) -> Option<&A>
     where
         A: PartialOrd;
 
     /// Finds the elementwise maximum of the array, skipping NaN values.
+    ///
+    /// Even if there are multiple (equal) elements that are maxima, only one
+    /// is returned. (Which one is returned is unspecified and may depend on
+    /// the memory layout of the array.)
     ///
     /// **Warning** This method will return a NaN value if none of the values
     /// in the array are non-NaN values. Note that the NaN value might not be

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -20,7 +20,8 @@ fn test_argmin() {
     assert_eq!(a.argmin(), None);
 
     let a = array![[1, 0, 3], [2, 0, 6]];
-    assert_eq!(a.argmin(), Some((0, 1)));
+    let argmin = a.argmin();
+    assert!(argmin == Some((0, 1)) || argmin == Some((1, 1)));
 
     let a: Array2<i32> = array![[], []];
     assert_eq!(a.argmin(), None);
@@ -65,7 +66,8 @@ fn test_argmax() {
     assert_eq!(a.argmax(), None);
 
     let a = array![[1, 5, 6], [2, 0, 6]];
-    assert_eq!(a.argmax(), Some((0, 2)));
+    let argmax = a.argmax();
+    assert!(argmax == Some((0, 2)) || argmax == Some((1, 2)));
 
     let a: Array2<i32> = array![[], []];
     assert_eq!(a.argmax(), None);

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -1,12 +1,14 @@
 #[macro_use(array)]
 extern crate ndarray;
 extern crate ndarray_stats;
+extern crate quickcheck;
 
 use ndarray::prelude::*;
 use ndarray_stats::{
     interpolate::{Higher, Linear, Lower, Midpoint, Nearest},
     Quantile1dExt, QuantileExt,
 };
+use quickcheck::quickcheck;
 
 #[test]
 fn test_argmin() {
@@ -19,12 +21,15 @@ fn test_argmin() {
     let a = array![[1., 5., 3.], [2., ::std::f64::NAN, 6.]];
     assert_eq!(a.argmin(), None);
 
-    let a = array![[1, 0, 3], [2, 0, 6]];
-    let argmin = a.argmin();
-    assert!(argmin == Some((0, 1)) || argmin == Some((1, 1)));
-
     let a: Array2<i32> = array![[], []];
     assert_eq!(a.argmin(), None);
+}
+
+quickcheck! {
+    fn argmin_matches_min(data: Vec<f32>) -> bool {
+        let a = Array1::from(data);
+        a.argmin().map(|i| a[i]) == a.min().cloned()
+    }
 }
 
 #[test]
@@ -65,12 +70,15 @@ fn test_argmax() {
     let a = array![[1., 5., 3.], [2., ::std::f64::NAN, 6.]];
     assert_eq!(a.argmax(), None);
 
-    let a = array![[1, 5, 6], [2, 0, 6]];
-    let argmax = a.argmax();
-    assert!(argmax == Some((0, 2)) || argmax == Some((1, 2)));
-
     let a: Array2<i32> = array![[], []];
     assert_eq!(a.argmax(), None);
+}
+
+quickcheck! {
+    fn argmax_matches_max(data: Vec<f32>) -> bool {
+        let a = Array1::from(data);
+        a.argmax().map(|i| a[i]) == a.max().cloned()
+    }
 }
 
 #[test]


### PR DESCRIPTION
For performance, it's beneficial to avoid guaranteeing a particular iteration order. For example, the current implementation of `min` may return any of the minima because the iteration order of `ArrayBase.fold()` is unspecified. The current implementation of `argmin` does always return the first minimum (in logical order) since `ArrayBase.indexed_iter()` always iterates in logical order, but we may want to optimize the iteration order in the future.