### PR TITLE
Make argmin/max_skipnan use EmptyInput error type

### DIFF
--- a/src/quantile/mod.rs
+++ b/src/quantile/mod.rs
@@ -45,7 +45,7 @@ where
 
     /// Finds the index of the minimum value of the array skipping NaN values.
     ///
-    /// Returns `Err(MinMaxError::EmptyInput)` if the array is empty or none of the values in the array
+    /// Returns `Err(EmptyInput)` if the array is empty or none of the values in the array
     /// are non-NaN values.
     ///
     /// Even if there are multiple (equal) elements that are minima, only one
@@ -65,7 +65,7 @@ where
     ///                [2., 0., 6.]];
     /// assert_eq!(a.argmin_skipnan(), Ok((1, 1)));
     /// ```
-    fn argmin_skipnan(&self) -> Result<D::Pattern, MinMaxError>
+    fn argmin_skipnan(&self) -> Result<D::Pattern, EmptyInput>
     where
         A: MaybeNan,
         A::NotNan: Ord;
@@ -130,7 +130,7 @@ where
 
     /// Finds the index of the maximum value of the array skipping NaN values.
     ///
-    /// Returns `Err(MinMaxError::EmptyInput)` if the array is empty or none of the values in the array
+    /// Returns `Err(EmptyInput)` if the array is empty or none of the values in the array
     /// are non-NaN values.
     ///
     /// Even if there are multiple (equal) elements that are maxima, only one
@@ -150,7 +150,7 @@ where
     ///                [2., 0., 6.]];
     /// assert_eq!(a.argmax_skipnan(), Ok((1, 2)));
     /// ```
-    fn argmax_skipnan(&self) -> Result<D::Pattern, MinMaxError>
+    fn argmax_skipnan(&self) -> Result<D::Pattern, EmptyInput>
     where
         A: MaybeNan,
         A::NotNan: Ord;
@@ -319,7 +319,7 @@ where
         Ok(current_pattern_min)
     }
 
-    fn argmin_skipnan(&self) -> Result<D::Pattern, MinMaxError>
+    fn argmin_skipnan(&self) -> Result<D::Pattern, EmptyInput>
     where
         A: MaybeNan,
         A::NotNan: Ord,
@@ -337,7 +337,7 @@ where
         if min.is_some() {
             Ok(pattern_min)
         } else {
-            Err(MinMaxError::EmptyInput)
+            Err(EmptyInput)
         }
     }
 
@@ -386,7 +386,7 @@ where
         Ok(current_pattern_max)
     }
 
-    fn argmax_skipnan(&self) -> Result<D::Pattern, MinMaxError>
+    fn argmax_skipnan(&self) -> Result<D::Pattern, EmptyInput>
     where
         A: MaybeNan,
         A::NotNan: Ord,
@@ -404,7 +404,7 @@ where
         if max.is_some() {
             Ok(pattern_max)
         } else {
-            Err(MinMaxError::EmptyInput)
+            Err(EmptyInput)
         }
     }
 

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -10,7 +10,7 @@ use itertools::izip;
 use ndarray::array;
 use ndarray::prelude::*;
 use ndarray_stats::{
-    errors::{MinMaxError, QuantileError},
+    errors::{EmptyInput, MinMaxError, QuantileError},
     interpolate::{Higher, Interpolate, Linear, Lower, Midpoint, Nearest},
     Quantile1dExt, QuantileExt,
 };
@@ -51,10 +51,10 @@ fn test_argmin_skipnan() {
     assert_eq!(a.argmin_skipnan(), Ok((1, 0)));
 
     let a: Array2<f64> = array![[], []];
-    assert_eq!(a.argmin_skipnan(), Err(MinMaxError::EmptyInput));
+    assert_eq!(a.argmin_skipnan(), Err(EmptyInput));
 
     let a = arr2(&[[::std::f64::NAN; 2]; 2]);
-    assert_eq!(a.argmin_skipnan(), Err(MinMaxError::EmptyInput));
+    assert_eq!(a.argmin_skipnan(), Err(EmptyInput));
 }
 
 quickcheck! {
@@ -63,7 +63,7 @@ quickcheck! {
         let min = a.min_skipnan();
         let argmin = a.argmin_skipnan();
         if min.is_none() {
-            argmin == Err(MinMaxError::EmptyInput)
+            argmin == Err(EmptyInput)
         } else {
             a[argmin.unwrap()] == *min
         }
@@ -134,10 +134,10 @@ fn test_argmax_skipnan() {
     assert_eq!(a.argmax_skipnan(), Ok((1, 2)));
 
     let a: Array2<f64> = array![[], []];
-    assert_eq!(a.argmax_skipnan(), Err(MinMaxError::EmptyInput));
+    assert_eq!(a.argmax_skipnan(), Err(EmptyInput));
 
     let a = arr2(&[[::std::f64::NAN; 2]; 2]);
-    assert_eq!(a.argmax_skipnan(), Err(MinMaxError::EmptyInput));
+    assert_eq!(a.argmax_skipnan(), Err(EmptyInput));
 }
 
 quickcheck! {
@@ -146,7 +146,7 @@ quickcheck! {
         let max = a.max_skipnan();
         let argmax = a.argmax_skipnan();
         if max.is_none() {
-            argmax == Err(MinMaxError::EmptyInput)
+            argmax == Err(EmptyInput)
         } else {
             a[argmax.unwrap()] == *max
         }


### PR DESCRIPTION
Neither method uses the `UndefinedOrder` variant, so there's no reason to use the `MinMaxError` enum instead of just the `EmptyInput` struct.